### PR TITLE
added public init() method for swift 4.1 compatibility

### DIFF
--- a/Feathers/Core/LoggerHooks.swift
+++ b/Feathers/Core/LoggerHooks.swift
@@ -12,6 +12,8 @@ import ReactiveSwift
 /// Simple request logger
 public struct RequestLoggerHook: Hook {
 
+    public init() {}
+
     public func run(with hookObject: HookObject) -> SignalProducer<HookObject, AnyFeathersError> {
         print("request to \(hookObject.service.path) for method \(hookObject.method)")
         return SignalProducer(value: hookObject)


### PR DESCRIPTION
xcode throws an error Initializer is inaccessable due to 'internal' protection level

Apparently they made this change:

A default initializer has the same access level as the type it initializes, unless that type is defined as public. For a type that is defined as public, the default initializer is considered internal. If you want a public type to be initializable with a no-argument initializer when used in another module, you must explicitly provide a public no-argument initializer yourself as part of the type’s definition.

```
static let beforeHooks = Service.Hooks(all: [RequestLoggerHook()])
static let errorHooks = Service.Hooks(all: [RequestLoggerHook()])
```